### PR TITLE
Fix cash update when closing a short trade

### DIFF
--- a/src/trade/simple_sum_signals_executor.py
+++ b/src/trade/simple_sum_signals_executor.py
@@ -21,11 +21,7 @@ class SimpleSumSignalsExecutor(SignalsExecutor):
         # close when there is no signal
         if len(signals) == 0 and candle.symbol in self.position and self.position[candle.symbol] != 0:
 
-            if self.position[candle.symbol] > 0:
-                self.cash += candle.close * self.position[candle.symbol]
-            else:
-                self.cash -= candle.close * self.position[candle.symbol]
-
+            self.cash += candle.close * self.position[candle.symbol]
             self.position[candle.symbol] = 0
 
         for signal in signals:

--- a/tests/unit/test_simple_sum_signals_executor.py
+++ b/tests/unit/test_simple_sum_signals_executor.py
@@ -1,0 +1,38 @@
+from datetime import datetime
+from unittest import TestCase
+
+from entities.candle import Candle
+from entities.strategy_signal import StrategySignal, SignalDirection
+from entities.timespan import TimeSpan
+from trade.simple_sum_signals_executor import DEFAULT_ORDER_VALUE, SimpleSumSignalsExecutor
+from unit import TEST_SYMBOL, generate_candle_with_price
+
+
+class TestSimpleSumSignalsExecutor(TestCase):
+    def test_open_and_close_long(self):
+        executor = SimpleSumSignalsExecutor()
+        candle = generate_candle_with_price(TimeSpan.Day, datetime.now(), DEFAULT_ORDER_VALUE)
+        signal = StrategySignal(TEST_SYMBOL, SignalDirection.Long)
+        # test opening a long trade
+        executor.execute(candle, [signal])
+        self.assertEqual(1, executor.position[TEST_SYMBOL])
+        self.assertEqual(-DEFAULT_ORDER_VALUE, executor.cash)
+        # test closing a long trade
+        candle = generate_candle_with_price(TimeSpan.Day, datetime.now(), DEFAULT_ORDER_VALUE + 88)
+        executor.execute(candle, [])
+        self.assertEqual(0, executor.position[TEST_SYMBOL])
+        self.assertEqual(88, executor.cash)
+
+    def test_open_and_close_short(self):
+        executor = SimpleSumSignalsExecutor()
+        candle = generate_candle_with_price(TimeSpan.Day, datetime.now(), DEFAULT_ORDER_VALUE)
+        signal = StrategySignal(TEST_SYMBOL, SignalDirection.Short)
+        # test opening a short trade
+        executor.execute(candle, [signal])
+        self.assertEqual(-1, executor.position[TEST_SYMBOL])
+        self.assertEqual(DEFAULT_ORDER_VALUE, executor.cash)
+        # test closing a short trade
+        candle = generate_candle_with_price(TimeSpan.Day, datetime.now(), DEFAULT_ORDER_VALUE - 88)
+        executor.execute(candle, [])
+        self.assertEqual(0, executor.position[TEST_SYMBOL])
+        self.assertEqual(88, executor.cash)


### PR DESCRIPTION
Fix cash update when closing a short trade (see #5).

Also added unit tests covering opening and closing for long and short trades. I reviewed the other tests, but let me know if the structure of the tests is OK etc. They run OK:

```
$ bash ./test-unit.sh
...................................
----------------------------------------------------------------------
Ran 35 tests in 0.174s

OK
```