### PR TITLE
Introduce multiple pipeline and extract shared context

### DIFF
--- a/src/assets/bins.json
+++ b/src/assets/bins.json
@@ -1,0 +1,1 @@
+{"__class__": "entities.bucketscontainer:BucketsContainer"}

--- a/src/assets/correlation.json
+++ b/src/assets/correlation.json
@@ -1,0 +1,32 @@
+{
+  "groups": [
+    [
+      "AAPL",
+      "MSFT",
+      "TSM",
+      "NVDA",
+      "ASML",
+      "ASMLF",
+      "AVGO",
+      "ADBE",
+      "CSCO",
+      "ACN",
+      "ORCL",
+      "CRM",
+      "QCOM",
+      "INTC",
+      "INTU",
+      "TXN",
+      "AMD",
+      "SAP",
+      "SAPGF",
+      "SONY",
+      "SNEJF",
+      "AMAT",
+      "KYCCF",
+      "IBM",
+      "NOW",
+      "SHOP"
+    ]
+  ]
+}

--- a/src/main.py
+++ b/src/main.py
@@ -1,12 +1,11 @@
 import json
-import os
-from os import path
+import pathlib
 
 from logger import setup_logger
 from pipeline.builders.backtest import BacktestPipelines
 from pipeline.builders.loaders import LoadersPipelines
-from pipeline.runner import PipelineSpecificationRunner
-from pipeline.specification import PipelineSpecification
+from pipeline.runner import PipelineRunner
+from pipeline.pipeline import Pipeline
 from serialization.store import DeserializationService
 
 BIN_COUNT = 10
@@ -15,19 +14,20 @@ BIN_COUNT = 10
 Main entry point, you can use the LoadersPipelines or the BacktestPipelines in order to run an example pipeline. 
 This should eventually be the CLI entrypoint. For now, it's for running examples.
 '''
-EXAMPLE_TEMPLATES_DIR = 'examples/pipeline-templates'
+EXAMPLE_TEMPLATES_DIR = pathlib.Path(__file__).parent.joinpath('examples/pipeline-templates').resolve()
+ASSETS_DIR = pathlib.Path(__file__).parent.joinpath('assets').resolve()
 
 
-def save_pipeline_spec(filename: str, spec: PipelineSpecification):
-    if not path.exists(EXAMPLE_TEMPLATES_DIR):
-        os.mkdir(EXAMPLE_TEMPLATES_DIR)
+def save_pipeline_spec(filename: str, pipeline: Pipeline):
+    if not pathlib.Path.exists(EXAMPLE_TEMPLATES_DIR):
+        pathlib.Path.mkdir(EXAMPLE_TEMPLATES_DIR)
 
-    with open(path.join(EXAMPLE_TEMPLATES_DIR, filename), 'w') as output_file:
-        output_file.write(json.dumps(spec.serialize(), indent=2, default=str))
+    with open(pathlib.Path(EXAMPLE_TEMPLATES_DIR).joinpath(filename), 'w') as output_file:
+        output_file.write(json.dumps(pipeline.serialize(), indent=2, default=str))
 
 
-def load_pipeline_spec(filename: str) -> PipelineSpecification:
-    with open(path.join(EXAMPLE_TEMPLATES_DIR, filename), 'r') as input_file:
+def load_pipeline_spec(filename: str) -> Pipeline:
+    with open(pathlib.Path(EXAMPLE_TEMPLATES_DIR).joinpath(filename), 'r') as input_file:
         return DeserializationService.deserialize(json.loads(input_file.read()))
 
 
@@ -35,22 +35,22 @@ def generate_example_templates():
     save_pipeline_spec('backtest_mongo_source_rsi_strategy.json', BacktestPipelines.build_mongodb_backtester())
     save_pipeline_spec('backtest_history_buckets_backtester.json',
                        BacktestPipelines.build_mongodb_history_buckets_backtester(
-                           'examples/pipeline-templates/bins.json'))
+                           f'{ASSETS_DIR}/bins.json'))
 
     save_pipeline_spec('backtest_technicals_with_buckets_calculator.json',
                        LoadersPipelines.build_technicals_with_buckets_calculator(
-                           'examples/pipeline-templates/bins.json', BIN_COUNT,
-                           'examples/pipeline-templates/correlation.json'))
+                           f'{ASSETS_DIR}/bins.json', BIN_COUNT,
+                           f'{ASSETS_DIR}/correlation.json'))
 
     save_pipeline_spec('loader_simple_technicals_calculator.json', LoadersPipelines.build_technicals_calculator())
     save_pipeline_spec('loader_simple_returns_calculator.json', LoadersPipelines.build_returns_calculator())
     save_pipeline_spec('loader_technicals_with_buckets_matcher.json',
-                       LoadersPipelines.build_technicals_with_buckets_matcher('examples/pipeline-templates/bins.json',
-                                                                              'examples/pipeline-templates/correlation.json'))
+                       LoadersPipelines.build_technicals_with_buckets_matcher(f'{ASSETS_DIR}/bins.json',
+                                                                              f'{ASSETS_DIR}/correlation.json'))
 
     save_pipeline_spec('backtest_history_similarity_backtester.json',
                        BacktestPipelines.build_mongodb_history_similarity_backtester(
-                           'examples/pipeline-templates/bins.json'))
+                           f'{ASSETS_DIR}/bins.json'))
 
     # depends on a running IB gateway
     # save_pipeline_spec('loader_simple_daily_loader.json', LoadersPipelines.build_daily_ib_loader())
@@ -62,5 +62,5 @@ if __name__ == '__main__':
     # generate_example_templates()
 
     # LOAD SAVED JSON PIPELINE AND RUN IT
-    spec = load_pipeline_spec('backtest_history_similarity_backtester.json')
-    PipelineSpecificationRunner(spec).run()
+    pipeline = load_pipeline_spec('backtest_history_similarity_backtester.json')
+    PipelineRunner(pipeline).run()

--- a/src/pipeline/builders/loaders.py
+++ b/src/pipeline/builders/loaders.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from assets.assets_provider import AssetsProvider
 from entities.timespan import TimeSpan
+
 from pipeline.processor import Processor
 from pipeline.processors.assets_correlation import AssetCorrelationProcessor
 from pipeline.processors.candle_cache import CandleCache
@@ -13,21 +14,19 @@ from pipeline.processors.technicals_buckets_matcher import TechnicalsBucketsMatc
 from pipeline.processors.technicals_normalizer import TechnicalsNormalizerProcessor
 from pipeline.processors.timespan_change import TimeSpanChangeProcessor
 from pipeline.reverse_source import ReverseSource
-from pipeline.runner import PipelineRunner
 from pipeline.source import Source
 from pipeline.sources.ib_history import IBHistorySource
 from pipeline.sources.mongodb_source import MongoDBSource
-from pipeline.specification import PipelineSpecification
+from pipeline.pipeline import Pipeline
 from pipeline.terminators.technicals_binner import TechnicalsBinner
 from providers.ib.interactive_brokers_connector import InteractiveBrokersConnector
 from storage.mongodb_storage import MongoDBStorage
 
 DEFAULT_DAYS_BACK = 365 * 1
 
-
 class LoadersPipelines:
     @staticmethod
-    def build_daily_ib_loader(days_back: int = DEFAULT_DAYS_BACK) -> PipelineSpecification:
+    def build_daily_ib_loader(days_back: int = DEFAULT_DAYS_BACK) -> Pipeline:
         mongodb_storage = MongoDBStorage()
 
         from_time = datetime.now() - timedelta(days=days_back)
@@ -39,10 +38,10 @@ class LoadersPipelines:
         cache_processor = CandleCache(sink)
         processor = TechnicalsProcessor(cache_processor)
 
-        return PipelineSpecification(source, processor)
+        return Pipeline(source, processor)
 
     @staticmethod
-    def build_returns_calculator(days_back: int = DEFAULT_DAYS_BACK) -> PipelineSpecification:
+    def build_returns_calculator(days_back: int = DEFAULT_DAYS_BACK) -> Pipeline:
         mongodb_storage = MongoDBStorage()
         symbols = AssetsProvider.get_sp500_symbols()
 
@@ -54,7 +53,7 @@ class LoadersPipelines:
         cache_processor = CandleCache(sink)
         processor = ReturnsCalculatorProcessor(cache_processor)
 
-        return PipelineSpecification(source, processor)
+        return Pipeline(source, processor)
 
     @staticmethod
     def _build_mongo_source(days_back: int) -> Source:
@@ -88,15 +87,15 @@ class LoadersPipelines:
         return timespan_change_processor
 
     @staticmethod
-    def build_technicals_calculator(days_back: int = DEFAULT_DAYS_BACK) -> PipelineSpecification:
+    def build_technicals_calculator(days_back: int = DEFAULT_DAYS_BACK) -> Pipeline:
         source = LoadersPipelines._build_mongo_source(days_back)
         technicals = LoadersPipelines._build_technicals_base_processor_chain()
-        return PipelineSpecification(source, technicals)
+        return Pipeline(source, technicals)
 
     @staticmethod
     def build_technicals_with_buckets_calculator(bins_file_path: str, bins_count: int,
                                                  correlations_file_path: str,
-                                                 days_back: int = DEFAULT_DAYS_BACK) -> PipelineSpecification:
+                                                 days_back: int = DEFAULT_DAYS_BACK) -> Pipeline:
         source = LoadersPipelines._build_mongo_source(days_back)
         technicals = LoadersPipelines._build_technicals_base_processor_chain(
             correlations_file_path=correlations_file_path)
@@ -104,14 +103,14 @@ class LoadersPipelines:
         symbols = AssetsProvider.get_sp500_symbols()
         technicals_binner = TechnicalsBinner(symbols, bins_count, bins_file_path)
 
-        return PipelineSpecification(source, technicals, technicals_binner)
+        return Pipeline(source, technicals, technicals_binner)
 
     @staticmethod
     def build_technicals_with_buckets_matcher(bins_file_path: str,
                                               correlations_file_path: str,
-                                              days_back: int = DEFAULT_DAYS_BACK) -> PipelineSpecification:
+                                              days_back: int = DEFAULT_DAYS_BACK) -> Pipeline:
         source = LoadersPipelines._build_mongo_source(days_back)
 
         technicals = LoadersPipelines._build_technicals_base_processor_chain(bins_file_path, correlations_file_path)
 
-        return PipelineSpecification(source, technicals)
+        return Pipeline(source, technicals)

--- a/src/pipeline/runner.py
+++ b/src/pipeline/runner.py
@@ -1,34 +1,21 @@
 import logging
-from typing import Optional
+from typing import List, Union
 
-from pipeline.processor import Processor
+from pipeline.pipeline import Pipeline
 from pipeline.shared_context import SharedContext
-from pipeline.source import Source
-from pipeline.specification import PipelineSpecification
-from pipeline.terminator import Terminator
 
 
 class PipelineRunner:
     logger = logging.getLogger('PipelineRunner')
 
-    def __init__(self, source: Source, processor: Processor, terminator: Optional[Terminator] = None) -> None:
-        self.source = source
-        self.processor = processor
-        self.terminator = terminator
+    def __init__(self, pipelines: Union[Pipeline, List[Pipeline]], context = SharedContext()) -> None:
+        if pipelines is not list:
+            pipelines = [pipelines]
+     
+        self.pipelines = pipelines
+        self.context = context
 
     def run(self):
-        self.logger.info('starting pipeline...')
-        context = SharedContext()
-        for candle in self.source.read():
-            self.processor.process(context, candle)
-
-        if self.terminator:
-            self.terminator.terminate(context)
-
-
-class PipelineSpecificationRunner:
-    def __init__(self, specification: PipelineSpecification):
-        self.runner = PipelineRunner(specification.source, specification.processor, specification.terminator)
-
-    def run(self):
-        self.runner.run()
+        self.logger.info('Starting pipeline runner...')
+        for pipeline in self.pipelines:
+            pipeline.run(self.context)


### PR DESCRIPTION
Recap of proposal #3
> Encapsulating a Pipeline into a `Pipeline` and having the `PipelineRunner` accept multiple `Pipeline` (as an array) sounds good to me. That will enable us to create multiple pipelines running sequentially and share data between them. We'll also need to enrich `PipelineSpecification` to accept multiple `Pipeline` instances.

> So the action items as I see them are:
> 
> 1. Create a `Pipeline` class that will hold the Source, processor, and terminator.
> 2. Extend `PipelineRunner` to accept a list of `Pipeline`
> 3. Move `PipelineRunner.run()` to `Pipeline` and implement a higher level `run()` on the `PipelineRunner` level (that invokes each `Pipeline` internal `run()`, sequentially.
> 4. `PipelineSpecification` would hold a list of the new `Pipeline` objects
> 5. inject `SharedContext` to the `PipelineRunner` and pass it to each `Pipeline.run()` call.


- Combine `PipelineSpecification` to `Pipeline`, originally, I had planned to use a conversion between `PipelineSpecification` to `Pipeline`, however after building `Pipeline` the code was too similar to the specification sans the `run` method, so I combined them and renamed the specification and kept the serialization features intact.

- Combines `PipelineRunner` back to one class, accepts either a list of Pipeline or single Pipeline. Calls `Pipeline.run` and injects `SharedContext` sequentially as discussed.

- Adjust `main.py` to use path resolution and pathlib import instead of os path, as on Windows I was getting some relative pathing errors with the provided examples. Use string interpolation when possible.

Question for @idanya:

Do you think we going to use the assets folder or the examples folder to hold the bins, correlation data? Sorry for the scope creep on the path stuff here, 